### PR TITLE
explicitly state the resample algorithm to avoid antialiasing being u…

### DIFF
--- a/pdf417/rendering.py
+++ b/pdf417/rendering.py
@@ -63,7 +63,7 @@ def render_image(codes, scale=3, ratio=3, padding=20, fg_color="#000",
         px[x, y] = fg_color if visible else bg_color
 
     # Scale and add padding
-    image = image.resize((scale * width, scale * height * ratio))
+    image = image.resize((scale * width, scale * height * ratio), resample=Image.NEAREST)
     image = ImageOps.expand(image, padding, bg_color)
 
     return image


### PR DESCRIPTION
…sed by default

It appears as if by default an antialiasing algorithm is used, at least when I run the code. The resulting image is blurry and won't be read properly by scanners. switching to Image.NEAREST solved that issue.
see also: https://pillow.readthedocs.io/en/3.2.x/reference/Image.html#PIL.Image.Image.resize