### PR TITLE
Encoder and console utility: add truncated pdf417 (Appendix F)

### DIFF
--- a/pdf417/console.py
+++ b/pdf417/console.py
@@ -18,6 +18,7 @@ def encode_data(args):
         security_level=args.security_level,
         encoding=args.encoding,
         numeric_compaction=args.numeric_compaction,
+        truncate=args.truncate
     )
 
     image = render_image(
@@ -70,6 +71,9 @@ subparser.add_argument("-r", "--ratio", dest="ratio", type=int, default=3,
 
 subparser.add_argument("-p", "--padding", default=20, type=int,
                        help="Image padding in pixels (default is 20).")
+
+subparser.add_argument("-t", "--truncate", action="store_true",
+                       help="Truncate stop pattern (default is False).")
 
 subparser.add_argument("-f", "--foreground-color", dest="fg_color", type=str,
                        help="Foreground color in hex (default is '#000000').",

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -23,6 +23,7 @@ def test_encode(render_image, encode, capsys, arguments):
         encoding='utf-8',
         security_level=2,
         numeric_compaction=False,
+        truncate=False,
     )
 
     render_image.assert_called_once_with(


### PR DESCRIPTION
According to Appendix F(https://www.expresscorp.com/uploads/specifications/44/USS-PDF-417.pdf): stop pattern can be shortened.